### PR TITLE
Add info-level logging to MCP streaming endpoint

### DIFF
--- a/src/Asynkron.OtelReceiver/Services/context.md
+++ b/src/Asynkron.OtelReceiver/Services/context.md
@@ -7,7 +7,7 @@ This directory contains gRPC service implementations wired into the ASP.NET Core
 - [`MetricsServiceImpl.cs`](MetricsServiceImpl.cs) – processes OTLP metrics synchronously: combines resource/scope attributes, normalises timestamps per metric type, persists via `ModelRepo.SaveMetrics` once per request to avoid duplicating rows, and records ingestion totals.
 - [`ReceiverMetricsServiceImpl.cs`](ReceiverMetricsServiceImpl.cs) – exposes a server-streaming endpoint backed by `IReceiverMetricsCollector.WatchAsync`, allowing external tooling (e.g., `ReceiverMetricsConsole`) to observe live counts.
 - [`DataServiceImpl.cs`](DataServiceImpl.cs) – surfaces TraceLens search, metadata, and metrics queries so clients can explore persisted telemetry, including the enriched search responses (attribute clause matches and optional span protos).
-- [`McpStreamingEndpoint.cs`](McpStreamingEndpoint.cs) – provides a newline-delimited JSON streaming HTTP endpoint that mirrors the TraceLens DataService gRPC commands for Model Context Protocol clients.
+- [`McpStreamingEndpoint.cs`](McpStreamingEndpoint.cs) – provides a newline-delimited JSON streaming HTTP endpoint that mirrors the TraceLens DataService gRPC commands for Model Context Protocol clients and now logs handshake, request, and response payloads at information level for easier diagnostics.
 
 Supporting infrastructure:
 - Channel batching is implemented in [`../TraceLens/Infra/ChannelExtensions.cs`](../TraceLens/Infra/ChannelExtensions.cs).


### PR DESCRIPTION
## Summary
- emit information-level logs for the MCP handshake, incoming commands, and outgoing responses
- add a helper to format payloads for logging without altering command processing
- document the new diagnostics behavior in the Services context guide

## Testing
- dotnet build
- dotnet test

------
https://chatgpt.com/codex/tasks/task_e_68db7a6901c48328bc67b1567928eff8