### PR TITLE
Package receiver as dotnet tool

### DIFF
--- a/context.md
+++ b/context.md
@@ -15,6 +15,7 @@ This repository hosts the **Asynkron OTLP Receiver**, a .NET 8 solution for inge
 - gRPC endpoints implementing OTLP trace, log, metric, and custom receiver-metrics services.
 - Entity Framework Core models and migrations backing SQLite storage.
 - TraceLens domain model (component/group extraction, timeline calculations, metrics helpers) used to interpret OTLP payloads.
+- Distributable as the `dotnet-otelmcp` global tool so operators can run the receiver via `dotnet otelmcp` with optional metrics streaming.
 - Generated OpenTelemetry protocol buffers that define the gRPC surface area consumed by the receiver.
 
 ## Where to look next

--- a/docs/context.md
+++ b/docs/context.md
@@ -5,6 +5,7 @@ This folder collects user-facing operational guides, integration notes, and rese
 Current entries:
 
 - [`aspire-sample-integration.md`](aspire-sample-integration.md) – step-by-step instructions for running the vendored .NET Aspire Shop sample against the receiver to generate realistic OTLP traffic.
+- [`dotnet-tool.md`](dotnet-tool.md) – installation and usage notes for the `dotnet-otelmcp` global tool, including `--address` and `--metrics-client` guidance.
 - [`tracelens-search.md`](tracelens-search.md) – outlines the composable `SearchTraces` filter expression so API consumers can combine service and attribute predicates with AND/OR logic.
 - [`tracelens-search-response.md`](tracelens-search-response.md) – documents the enriched `SearchTraces` response payload (attribute clause matches and optional span protos) so UI/CLI clients can adopt the new metadata.
 

--- a/docs/dotnet-tool.md
+++ b/docs/dotnet-tool.md
@@ -1,0 +1,52 @@
+# `dotnet-otelmcp` Global Tool
+
+The receiver project can be distributed as a .NET global tool named `dotnet-otelmcp`. Installing the tool provides the `dotnet otelmcp` command that boots the OTLP receiver, applies EF Core migrations, and exposes the optional metrics console client.
+
+## Installation
+
+Install from NuGet once the package is published:
+
+```bash
+# Installs the published package from nuget.org
+dotnet tool install --global dotnet-otelmcp
+```
+
+During local development you can install directly from a packed `.nupkg` folder:
+
+```bash
+# Replace ./nupkg with the folder produced by `dotnet pack`
+dotnet tool install --global --add-source ./nupkg dotnet-otelmcp
+```
+
+Ensure that the global tool path is on your `PATH` (typically `~/.dotnet/tools`).
+
+## Running the Receiver
+
+Starting the server uses the default `appsettings.json` connection strings bundled with the tool. On first launch the Entity Framework Core migrations execute automatically to create or upgrade the backing database.
+
+```bash
+# Launch the OTLP receiver (the global tool shim is also exposed as `otelmcp`)
+dotnet otelmcp
+```
+
+> **Note:** The `dotnet` driver resolves to the same shim the global tool installs. If your shell cannot locate the command via `dotnet otelmcp`, invoke `otelmcp` directly.
+
+### Selecting a Bind Address
+
+Use `--address` to specify the HTTP/gRPC listener (defaults to `http://localhost:5000`).
+
+```bash
+# Bind to all interfaces on port 7171
+dotnet otelmcp --address http://0.0.0.0:7171
+```
+
+## Metrics Console
+
+The tool also includes a live metrics console implemented with Spectre.Console.
+
+```bash
+# Connect the metrics console to a running receiver instance
+dotnet otelmcp --metrics-client --address http://localhost:5000
+```
+
+When `--metrics-client` is provided the process connects to the server instead of hosting it, streaming ingestion counters in real time.

--- a/src/Asynkron.OtelReceiver/Asynkron.OtelReceiver.csproj
+++ b/src/Asynkron.OtelReceiver/Asynkron.OtelReceiver.csproj
@@ -5,6 +5,11 @@
     <Nullable>enable</Nullable>
     <ImplicitUsings>enable</ImplicitUsings>
     <LangVersion>preview</LangVersion>
+    <OutputType>Exe</OutputType>
+    <PackAsTool>true</PackAsTool>
+    <ToolCommandName>otelmcp</ToolCommandName>
+    <PackageId>dotnet-otelmcp</PackageId>
+    <IsPackable>true</IsPackable>
   </PropertyGroup>
 
   <ItemGroup>
@@ -66,6 +71,13 @@
   <ItemGroup>
     <Compile Remove="ProtoGenerated/**/*.cs" />
     <None Include="ProtoGenerated/**/*.cs" />
+  </ItemGroup>
+
+  <ItemGroup>
+    <!-- Ensure runtime configuration files ship with the global tool package -->
+    <Content Update="appsettings.json">
+      <CopyToOutputDirectory>PreserveNewest</CopyToOutputDirectory>
+    </Content>
   </ItemGroup>
 
 </Project>

--- a/src/Asynkron.OtelReceiver/Program.cs
+++ b/src/Asynkron.OtelReceiver/Program.cs
@@ -5,6 +5,7 @@ using Asynkron.OtelReceiver.Monitoring;
 using Asynkron.OtelReceiver.Services;
 using Microsoft.EntityFrameworkCore;
 using Microsoft.Extensions.DependencyInjection;
+using Microsoft.AspNetCore.Server.Kestrel.Core;
 
 // The application can either run the OTLP receiver ASP.NET Core host or attach to an existing
 // instance and print its metrics. We use a simple flag so the tool remains easy to run.
@@ -15,7 +16,20 @@ if (args.Any(a => string.Equals(a, "--metrics-client", StringComparison.OrdinalI
     return;
 }
 
-var builder = WebApplication.CreateBuilder(args);
+var (applicationArgs, bindingAddress) = ExtractAddressArguments(args);
+
+var builder = WebApplication.CreateBuilder(applicationArgs);
+
+if (!string.IsNullOrWhiteSpace(bindingAddress))
+{
+    builder.WebHost.UseUrls(bindingAddress);
+}
+
+builder.WebHost.ConfigureKestrel(options =>
+{
+    options.ConfigureEndpointDefaults(listenOptions =>
+        listenOptions.Protocols = HttpProtocols.Http2);
+});
 
 var sqliteConnectionString = builder.Configuration.GetConnectionString("DefaultConnection")
                              ?? "Data Source=otel.db";
@@ -49,3 +63,40 @@ await using (var scope = app.Services.CreateAsyncScope())
 }
 
 await app.RunAsync();
+
+static (string[] RemainingArgs, string? Address) ExtractAddressArguments(string[] sourceArgs)
+{
+    var remainingArgs = new List<string>(sourceArgs.Length);
+    string? address = null;
+
+    for (var i = 0; i < sourceArgs.Length; i++)
+    {
+        var argument = sourceArgs[i];
+
+        if (argument.StartsWith("--address=", StringComparison.OrdinalIgnoreCase))
+        {
+            address = argument[10..];
+        }
+        else if (string.Equals(argument, "--address", StringComparison.OrdinalIgnoreCase))
+        {
+            if (i + 1 >= sourceArgs.Length)
+            {
+                throw new ArgumentException("The --address option requires a value.");
+            }
+
+            address = sourceArgs[i + 1];
+            i++; // Skip the value.
+        }
+        else
+        {
+            remainingArgs.Add(argument);
+        }
+    }
+
+    if (address is not null && string.IsNullOrWhiteSpace(address))
+    {
+        throw new ArgumentException("The --address option requires a non-empty value.");
+    }
+
+    return (remainingArgs.ToArray(), address);
+}

--- a/src/Asynkron.OtelReceiver/context.md
+++ b/src/Asynkron.OtelReceiver/context.md
@@ -1,6 +1,7 @@
 # `Asynkron.OtelReceiver` Project Context
 
-This ASP.NET Core gRPC service ingests OTLP telemetry and persists it using Entity Framework Core. Key entry points:
+This ASP.NET Core gRPC service ingests OTLP telemetry and persists it using Entity Framework Core. The project now also packs as
+the global tool `dotnet-otelmcp`, enabling the server to run via `dotnet otelmcp`. Key entry points:
 
 - [`Program.cs`](Program.cs) bootstraps the web host, wires up the SQLite-backed EF Core factory, registers ingestion services, and ensures migrations are applied at startup.
 - [`ReceiverMetricsConsole.cs`](ReceiverMetricsConsole.cs) provides a Spectre.Console CLI that connects to the running receiver (via `--metrics-client`) and streams live ingestion counters.


### PR DESCRIPTION
## Summary
- enable the Asynkron.OtelReceiver project to pack as a global tool and ensure runtime config ships with the package
- add CLI address parsing plus HTTP/2 hosting defaults so the packaged tool can bind custom endpoints and serve gRPC
- document installing and running the `dotnet-otelmcp` tool and update repository context summaries

## Testing
- dotnet build Asynkron.OtelReceiver.sln
- dotnet test Asynkron.OtelReceiver.sln
- dotnet pack src/Asynkron.OtelReceiver/Asynkron.OtelReceiver.csproj -c Release
- otelmcp --address http://127.0.0.1:5191
- otelmcp --metrics-client --address http://127.0.0.1:5191

------
https://chatgpt.com/codex/tasks/task_e_68db9f5d48588328bb6fe1ed96249d1a